### PR TITLE
Make random users able to initialize the git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "git"]
 	path = git
-	url = git@github.com:ryppl/git
+	url = https://github.com/ryppl/git.git


### PR DESCRIPTION
As janosvitok pointed out, users without write access to the ryppl repositories are unable to initialize the git submodule because it is referenced by a git-uri.
This change addresses this issue. And users who do actually have write access can ofcourse easily add a writable remote to the submodule.
