### PR TITLE
Partially fix the sandbox/boost_docs branch.

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -2326,6 +2326,10 @@ repository boostbook : common_branches
   {
     "tools/boostbook/";
   }
+  branches
+  {
+    [:] "/sandbox/boost_docs/trunk/" : "sandbox/boost_docs";
+  }
 }
 
 // ==============================================================
@@ -2534,6 +2538,7 @@ repository quickbook : common_branches
   branches
   {
     [:] "/branches/quickbook/include/boost/" : "quickbook/include";
+    [:] "/sandbox/boost_docs/trunk/" : "sandbox/boost_docs";
   }
 }
 
@@ -2622,7 +2627,6 @@ repository website
   content
   {
     "doc/" : "doc/";
-    "tools/" : "tools/";
   }
   branches
   {


### PR DESCRIPTION
I just noticed the 'sandbox/boost_docs' branch in the website repo,
which has nothing to do with the website. I've tried to move the
boostbook and quickbook parts of that branch to the correct repos.

I'm not sure what should be done with the rest, the 'doc' directory
appears to belong with the boost super-project. I don't think we really
need to preserve it.
